### PR TITLE
#26038 add flotiq-nextjs-setup cli description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,23 @@ This project use:
     yarn install
     ```
 
-5. **Flotiq codegen**
+5. **Flotiq codegen - install SDK**
 
    This package simplifies Typescript Fetch API integration for your Flotiq project, tailored to your Flotiq account 
-   data. To build your customized API package, just run this command:
+   data.
+
+   To install Flotiq SDK you can use flotiq-nextjs-setup CLI, that will not only seemlessly generate SDK for your Next.js project, but will also add content cache revalidation endpoint, handle draft mode for unpublished content on Flotiq and more. To use the flotiq-nextjs-setup CLI simply:
+   - install flotiq-nextjs-setup CLI:
+       ```bash
+       npm install -g flotiq-nextjs-setup
+       ```
+   - run the setup:
+       ```bash
+       npx flotiq-nextjs-setup
+       ```
+   If you want to read more about our flotiq-nextjs-setup CLI, refer to our [Flotiq NextJS docs](https://flotiq.com/docs/Universe/nextjs/nextjs-setup/).
+   
+   If instead you prefer to install only Flotiq SDK, manually, do the following steps:
 
    ```bash
    npx flotiq-codegen-ts generate --compiled-js


### PR DESCRIPTION
Added description on flotiq-nextjs-setup CLI for installing SDK in Next.js project

![image](https://github.com/user-attachments/assets/747056ec-ac9a-4474-ae6f-0a1a68e8ebd2)
